### PR TITLE
Don't use default timeouts of RestClient

### DIFF
--- a/lib/social_shares/base.rb
+++ b/lib/social_shares/base.rb
@@ -1,6 +1,6 @@
 module SocialShares
   class Base
-    TIMEOUT = OPEN_TIMEOUT = 5
+    TIMEOUT = OPEN_TIMEOUT = 3
     attr_accessor :checked_url
 
     def initialize(checked_url)

--- a/lib/social_shares/base.rb
+++ b/lib/social_shares/base.rb
@@ -1,5 +1,6 @@
 module SocialShares
   class Base
+    TIMEOUT = OPEN_TIMEOUT = 5
     attr_accessor :checked_url
 
     def initialize(checked_url)
@@ -12,6 +13,14 @@ module SocialShares
     rescue => e
       puts "[#{self.class.name}] Error during requesting sharings of '#{checked_url}': #{e}"
       nil
+    end
+
+    def get(url, params)
+      RestClient::Resource.new(url, timeout: TIMEOUT, open_timeout: OPEN_TIMEOUT).get(params)
+    end
+
+    def post(url, params, headers = {})
+      RestClient::Resource.new(url, timeout: TIMEOUT, open_timeout: OPEN_TIMEOUT).post(params, headers)
     end
 
     def shares!

--- a/lib/social_shares/buffer.rb
+++ b/lib/social_shares/buffer.rb
@@ -3,8 +3,10 @@ module SocialShares
     URL = 'https://api.bufferapp.com/1/links/shares.json'
 
     def shares!
-      response = RestClient.get(URL, {:params => {:url => checked_url}})
+      response = get(URL, {:params => {:url => checked_url}})
       JSON.parse(response)['shares']
+    rescue
+      0
     end
   end
 end

--- a/lib/social_shares/buffer.rb
+++ b/lib/social_shares/buffer.rb
@@ -5,8 +5,6 @@ module SocialShares
     def shares!
       response = get(URL, {:params => {:url => checked_url}})
       JSON.parse(response)['shares']
-    rescue
-      0
     end
   end
 end

--- a/lib/social_shares/facebook.rb
+++ b/lib/social_shares/facebook.rb
@@ -3,7 +3,7 @@ module SocialShares
     URL = 'https://graph.facebook.com/fql'
 
     def shares!
-      response = RestClient.get(URL, {
+      response = get(URL, {
         :params => {
           :q => "SELECT share_count FROM link_stat WHERE url='#{checked_url}'"
         }

--- a/lib/social_shares/google.rb
+++ b/lib/social_shares/google.rb
@@ -3,8 +3,10 @@ module SocialShares
     URL = 'https://clients6.google.com/rpc?key=AIzaSyCKSbrvQasunBoV16zDH9R33D88CeLr9gQ'
 
     def shares!
-      response = RestClient.post(URL, JSON.dump(params), content_type: :json, accept: :json)
+      response = post(URL, JSON.dump(params), {content_type: :json, accept: :json})
       JSON.parse(response)[0]['result']['metadata']['globalCounts']['count'].to_i
+    rescue
+      0
     end
 
   private

--- a/lib/social_shares/google.rb
+++ b/lib/social_shares/google.rb
@@ -5,8 +5,6 @@ module SocialShares
     def shares!
       response = post(URL, JSON.dump(params), {content_type: :json, accept: :json})
       JSON.parse(response)[0]['result']['metadata']['globalCounts']['count'].to_i
-    rescue
-      0
     end
 
   private

--- a/lib/social_shares/linkedin.rb
+++ b/lib/social_shares/linkedin.rb
@@ -10,8 +10,6 @@ module SocialShares
                     }
                   })
       JSON.parse(response)['count']
-    rescue
-      0
     end
   end
 end

--- a/lib/social_shares/linkedin.rb
+++ b/lib/social_shares/linkedin.rb
@@ -3,13 +3,15 @@ module SocialShares
     URL = 'http://www.linkedin.com/countserv/count/share'
 
     def shares!
-      response = RestClient.get(URL, {
-        :params => {
-          :url => checked_url,
-          :format => 'json'
-        }
-      })
+      response = get(URL, {
+                    :params => {
+                      :url => checked_url,
+                      :format => 'json'
+                    }
+                  })
       JSON.parse(response)['count']
+    rescue
+      0
     end
   end
 end

--- a/lib/social_shares/mail_ru.rb
+++ b/lib/social_shares/mail_ru.rb
@@ -3,7 +3,7 @@ module SocialShares
     URL = 'https://connect.mail.ru/share_count'
 
     def shares!
-      response = RestClient.get(URL, {
+      response = get(URL, {
         params: {
           func: 'foo',
           callback: 1,

--- a/lib/social_shares/pinterest.rb
+++ b/lib/social_shares/pinterest.rb
@@ -5,8 +5,6 @@ module SocialShares
     def shares!
       response = get(URL, {:params => {:url => checked_url}})
       /count":(\d+)/.match(response)[-1].to_i
-    rescue
-      0
     end
   end
 end

--- a/lib/social_shares/pinterest.rb
+++ b/lib/social_shares/pinterest.rb
@@ -3,8 +3,10 @@ module SocialShares
     URL = 'http://api.pinterest.com/v1/urls/count.json'
 
     def shares!
-      response = RestClient.get(URL, {:params => {:url => checked_url}})
+      response = get(URL, {:params => {:url => checked_url}})
       /count":(\d+)/.match(response)[-1].to_i
+    rescue
+      0
     end
   end
 end

--- a/lib/social_shares/reddit.rb
+++ b/lib/social_shares/reddit.rb
@@ -6,8 +6,6 @@ module SocialShares
       response = get(URL, {:params => {:url => checked_url}})
       children_data = JSON.parse(response)['data']['children']
       children_data.map{|c| c['data']['score']}.reduce(:+) || 0
-    rescue
-      0
     end
   end
 end

--- a/lib/social_shares/reddit.rb
+++ b/lib/social_shares/reddit.rb
@@ -3,9 +3,11 @@ module SocialShares
     URL = 'http://www.reddit.com/api/info.json'
 
     def shares!
-      response = RestClient.get(URL, {:params => {:url => checked_url}})
+      response = get(URL, {:params => {:url => checked_url}})
       children_data = JSON.parse(response)['data']['children']
       children_data.map{|c| c['data']['score']}.reduce(:+) || 0
+    rescue
+      0
     end
   end
 end

--- a/lib/social_shares/stumbleupon.rb
+++ b/lib/social_shares/stumbleupon.rb
@@ -5,8 +5,6 @@ module SocialShares
     def shares!
       response = get(URL, {:params => {:url => checked_url}})
       JSON.parse(response)['result']['views'] || 0
-    rescue
-      0
     end
   end
 end

--- a/lib/social_shares/stumbleupon.rb
+++ b/lib/social_shares/stumbleupon.rb
@@ -3,8 +3,10 @@ module SocialShares
     URL = 'http://www.stumbleupon.com/services/1.01/badge.getinfo'
 
     def shares!
-      response = RestClient.get(URL, {:params => {:url => checked_url}})
+      response = get(URL, {:params => {:url => checked_url}})
       JSON.parse(response)['result']['views'] || 0
+    rescue
+      0
     end
   end
 end

--- a/lib/social_shares/twitter.rb
+++ b/lib/social_shares/twitter.rb
@@ -3,8 +3,10 @@ module SocialShares
     URL = 'http://cdn.api.twitter.com/1/urls/count.json'
 
     def shares!
-      response = RestClient.get(URL, {:params => {:url => checked_url}})
+      response = get(URL, {:params => {:url => checked_url}})
       JSON.parse(response)['count']
+    rescue
+      0
     end
   end
 end

--- a/lib/social_shares/twitter.rb
+++ b/lib/social_shares/twitter.rb
@@ -5,8 +5,6 @@ module SocialShares
     def shares!
       response = get(URL, {:params => {:url => checked_url}})
       JSON.parse(response)['count']
-    rescue
-      0
     end
   end
 end

--- a/lib/social_shares/version.rb
+++ b/lib/social_shares/version.rb
@@ -1,3 +1,3 @@
 module SocialShares
-  VERSION = '0.2.5'
+  VERSION = '0.2.6'
 end

--- a/lib/social_shares/vkontakte.rb
+++ b/lib/social_shares/vkontakte.rb
@@ -3,14 +3,16 @@ module SocialShares
     URL = 'http://vk.com/share.php'
 
     def shares!
-      response = RestClient.get(URL, {
-        :params => {
-          :act => 'count',
-          :index => 1,
-          :url => checked_url,
-        }
-      })
+      response = get(URL, {
+                    :params => {
+                      :act => 'count',
+                      :index => 1,
+                      :url => checked_url,
+                    }
+                  })
       /VK.Share.count\(1,\s(\d+)\)/.match(response)[1].to_i
+    rescue
+      0
     end
   end
 end

--- a/lib/social_shares/vkontakte.rb
+++ b/lib/social_shares/vkontakte.rb
@@ -11,8 +11,6 @@ module SocialShares
                     }
                   })
       /VK.Share.count\(1,\s(\d+)\)/.match(response)[1].to_i
-    rescue
-      0
     end
   end
 end

--- a/lib/social_shares/weibo.rb
+++ b/lib/social_shares/weibo.rb
@@ -4,27 +4,31 @@ module SocialShares
     URL_FOR_SHARE = 'https://api.weibo.com/2/short_url/share/counts.json'
 
     def shares!
-      response = RestClient.get(URL_FOR_SHARE, {
-        :params => {
-          :_ => '1414437609900',
-          :source => '8003029170',
-          :url_short => short_url
-        }
-      })
+      response = get(URL_FOR_SHARE, {
+                    :params => {
+                      :_ => '1414437609900',
+                      :source => '8003029170',
+                      :url_short => short_url
+                    }
+                  })
       JSON.parse(response)['urls'].first['share_counts'].to_i
+    rescue
+      0
     end
 
   private
 
     def short_url
-      response = RestClient.get(URL_FOR_SHORT, {
-        :params => {
-          :_ => '1414437609673',
-          :source => '8003029170',
-          :url_long => checked_url
-        }
-      })
+      response = get(URL_FOR_SHORT, {
+                    :params => {
+                      :_ => '1414437609673',
+                      :source => '8003029170',
+                      :url_long => checked_url
+                    }
+                  })
       JSON.parse(response)['urls'].first['url_short']
+    rescue
+      0
     end
   end
 end

--- a/lib/social_shares/weibo.rb
+++ b/lib/social_shares/weibo.rb
@@ -12,8 +12,6 @@ module SocialShares
                     }
                   })
       JSON.parse(response)['urls'].first['share_counts'].to_i
-    rescue
-      0
     end
 
   private
@@ -27,8 +25,6 @@ module SocialShares
                     }
                   })
       JSON.parse(response)['urls'].first['url_short']
-    rescue
-      0
     end
   end
 end


### PR DESCRIPTION
- we also rescue when there is a timeout or no response and return 0
- also changed the facebook url to `URL = 'http://api.facebook.com/restserver.php` the previous one was giving forbidden error.

fixes #3 