### PR TITLE
Omit some social networks (opposite of #selected)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Fetch all shares by one method (#all, #all!):
  => RestClient::RequestTimeout: Request Timeout
 ```
 
+Fetch shares by excluding networks(#omit, #omit!):
+```ruby
+:000 > SocialShares.omit url, %w(facebook)
+ => { :google=>28289, :linkedin=>nil, ... }
+
+# same here
+:000 > SocialShares.omit! url, %w(facebook)
+ => RestClient::RequestTimeout: Request Timeout
+```
+
 Fetch shares of selected networks(#selected, #selected!):
 ```ruby
 :000 > SocialShares.selected url, %w(facebook google linkedin)

--- a/lib/social_shares.rb
+++ b/lib/social_shares.rb
@@ -50,6 +50,14 @@ module SocialShares
       end
     end
 
+    def omit(url, excluded_networks = [])
+      selected_base(url, supported_networks - excluded_networks, false)
+    end
+
+    def omit!(url, excluded_networks = [])
+      selected_base(url, supported_networks - excluded_networks, true)
+    end
+
     def selected(url, selected_networks)
       selected_base(url, selected_networks, false)
     end


### PR DESCRIPTION
####Usage

```ruby
:000> url = 'http://www.apple.com/'
=> "http://www.apple.com/"
:001> SocialShares.omit url, [:facebook, :google]
=> {:vkontakte=>43185, :twitter=>nil, :mail_ru=>104, :odnoklassniki=>74, :reddit=>nil, :linkedin=>200, :pinterest=>21229, :stumbleupon=>43035, :weibo=>nil, :buffer=>2271, :yandex=>0} 
```

#####TODO
- [x] add a #omit and a #omit! method that exclude some sn.
- [x] update README.md
