### PR TITLE
add rails caching to social shares count

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,39 @@ Does any network have at least one link?
 ```
 Note that #has_any? is faster than (#total > 0), because it stops on first network that has at least 1 sharing
 
+Caching
+-----
+
+The gem uses Rails.cache for caching. If you don't define any `cache_store` then rails will use the `file_store` by default and store the counts into the tmp directory.
+
+Here are some examples of configuration needed for caching with other serives than file_store:
+
+#### Redis:
+
+```ruby
+# Gemfile
+gem 'redis-rails'
+```
+
+```ruby
+# config/initializers/redis_store.rb
+redis_url = ENV["REDISCLOUD_URL"] || "redis://127.0.0.1:6379/0/social_shares"
+SocialShares::Application.config.cache_store = :redis_store, redis_url, { expires_in: 5.minutes }
+```
+
+#### Memcached:
+
+```ruby
+# Gemfile
+gem 'dalli'
+gem 'memcachier'
+```
+
+```ruby
+# config/environments/production.rb
+config.cache_store = :dalli_store, { expires_in: 5.minutes }
+```
+
 Try it by yourself before installation
 -----
 Send request through shell to test numbers. Please do NOT use this url in your projects.

--- a/lib/social_shares.rb
+++ b/lib/social_shares.rb
@@ -41,12 +41,14 @@ module SocialShares
     SUPPORTED_NETWORKS.each do |network_name|
       define_method(network_name) do |url|
         class_name = network_name.to_s.split('_').map(&:capitalize).join
-        SocialShares.const_get(class_name).new(url).shares
+        cache_name = "#{class_name}_#{url.parameterize.underscore}"
+        Rails.cache.fetch(cache_name) { SocialShares.const_get(class_name).new(url).shares }
       end
 
       define_method("#{network_name}!") do |url|
         class_name = network_name.to_s.split('_').map(&:capitalize).join
-        SocialShares.const_get(class_name).new(url).shares!
+        cache_name = "#{class_name}_#{url.parameterize.underscore}"
+        Rails.cache.fetch(cache_name) { SocialShares.const_get(class_name).new(url).shares! }
       end
     end
 


### PR DESCRIPTION
I made this simple change for adding caching to the gem. It's using the Rails.cache that defaults to file_store in case there is no cache_store defined.