### PR TITLE
Using response body to avoid Response#to_i warning

### DIFF
--- a/lib/social_shares/mail_ru.rb
+++ b/lib/social_shares/mail_ru.rb
@@ -11,7 +11,7 @@ module SocialShares
         }
       })
 
-      matches = /shares":(\d+)/.match(response)
+      matches = /shares":(\d+)/.match(response.body)
       matches ? matches[-1].to_i : 0
     end
   end

--- a/lib/social_shares/odnoklassniki.rb
+++ b/lib/social_shares/odnoklassniki.rb
@@ -11,7 +11,7 @@ module SocialShares
         }
       })
 
-      /'(\d+)'\)/.match(response)[-1].to_i
+      /'(\d+)'\)/.match(response.body)[-1].to_i
     end
   end
 end

--- a/lib/social_shares/pinterest.rb
+++ b/lib/social_shares/pinterest.rb
@@ -5,7 +5,7 @@ module SocialShares
     def shares!
       response = get(URL, params: { url: checked_url })
 
-      /count":(\d+)/.match(response)[-1].to_i
+      /count":(\d+)/.match(response.body)[-1].to_i
     end
   end
 end

--- a/lib/social_shares/vkontakte.rb
+++ b/lib/social_shares/vkontakte.rb
@@ -11,7 +11,7 @@ module SocialShares
         }
       })
 
-      /VK.Share.count\(1,\s(\d+)\)/.match(response)[1].to_i
+      /VK.Share.count\(1,\s(\d+)\)/.match(response.body)[1].to_i
     end
   end
 end


### PR DESCRIPTION
Matching raw response causes `warning: calling Response#to_i is not recommended`