### PR TITLE
Added new JSON endpoint for twitter shares

### DIFF
--- a/lib/social_shares.rb
+++ b/lib/social_shares.rb
@@ -28,7 +28,7 @@ module SocialShares
       :vkontakte,
       :facebook,
       :google,
-      # :twitter,
+      :twitter,
       :mail_ru,
       :odnoklassniki,
       :reddit,

--- a/lib/social_shares/twitter.rb
+++ b/lib/social_shares/twitter.rb
@@ -1,6 +1,6 @@
 module SocialShares
   class Twitter < Base
-    URL = 'http://cdn.api.twitter.com/1/urls/count.json'
+    URL = 'http://public.newsharecounts.com/count.json'
 
     def shares!
       response = get(URL, params: { url: checked_url })


### PR DESCRIPTION
Hey Tim, 

I've found a new API endpoint for twitter shares, which is provided by http://newsharecounts.com/. They've basically kept a huge database of twitter shares using the old api (which stopped working a while ago) and regularly crawls twitter for new mentions. 

Try it: http://public.newsharecounts.com/count.json?url=http://newsharecounts.com/