### PR TITLE
Ensure Stumbleupon returns an Integer

### DIFF
--- a/lib/social_shares/stumbleupon.rb
+++ b/lib/social_shares/stumbleupon.rb
@@ -4,8 +4,7 @@ module SocialShares
 
     def shares!
       response = get(URL, params: { url: checked_url })
-
-      JSON.parse(response)['result']['views'] || 0
+      JSON.parse(response).dig('result', 'views').to_i
     end
   end
 end


### PR DESCRIPTION
I found a bug in our app because we expected each of the results to return an Integer. However, it seems that Stumbleupon was returning a String rather than an Integer.

This would break things like:

``` ruby
SocialShares.all!(url).map { |c| c.last.to_i }.sum
```